### PR TITLE
Add reusable category lists

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import type {
   Settings,
   StylesChangeHandler,
 } from './types';
+import { ADVANCED_CATEGORIES, SIMPLE_CATEGORIES } from './types';
 import type { UIProps } from './ui';
 import { defaultSettings, regexps, sortStyles } from './utils';
 
@@ -120,16 +121,15 @@ export default async () => {
       await figma.loadFontAsync(fontNames[i]);
     }
 
-    const { japanese, kanji, kana, yakumono, number, normal } = fonts;
+    const { normal } = fonts;
+    const categoryList =
+      fontMode === 'simple' ? SIMPLE_CATEGORIES : ADVANCED_CATEGORIES;
     const categories: Partial<Record<Exclude<Category, 'normal'>, FontName>> =
-      fontMode === 'simple'
-        ? { japanese }
-        : {
-            kanji,
-            kana,
-            yakumono,
-            number,
-          };
+      {};
+    for (const key of categoryList) {
+      if (key === 'normal') continue;
+      categories[key] = fonts[key];
+    }
 
     const settings: Settings = { fonts, fontMode };
     if (saveSettings) await saveSettingsAsync(settings, 'fonts');

--- a/src/tabs/styles.tsx
+++ b/src/tabs/styles.tsx
@@ -17,6 +17,7 @@ import type {
   SimpleCategory,
   Style,
 } from '../types';
+import { ADVANCED_CATEGORIES, SIMPLE_CATEGORIES } from '../types';
 import { getFontWeight } from '../utils';
 import cssStyles from './styles.module.css';
 
@@ -24,22 +25,13 @@ const readableText = (style: Style) => {
   const { fonts: _fonts, fontMode } = style;
   if (fontMode === 'simple') {
     const fonts = _fonts as Record<SimpleCategory, FontName>;
-    return [
-      `${fonts['japanese'].family} ${fonts['japanese'].style}`,
-      `${fonts['normal'].family} ${fonts['normal'].style}`,
-    ]
+    return SIMPLE_CATEGORIES.map((c) => `${fonts[c].family} ${fonts[c].style}`)
       .filter((v, i, a) => a.indexOf(v) === i)
       .join(', ');
   }
   if (fontMode === 'advanced') {
     const fonts = _fonts as Record<AdvancedCategory, FontName>;
-    return [
-      fonts['kanji'].family,
-      fonts['kana'].family,
-      fonts['yakumono'].family,
-      fonts['number'].family,
-      fonts['normal'].family,
-    ]
+    return ADVANCED_CATEGORIES.map((c) => fonts[c].family)
       .filter((v, i, a) => a.indexOf(v) === i)
       .join(', ');
   }
@@ -50,28 +42,27 @@ const estimateWeight = (style: Style): number => {
   if (fontMode === 'simple') {
     const fonts = _fonts as Record<SimpleCategory, FontName>;
     return (
-      [
-        getFontWeight(fonts.japanese.style),
-        getFontWeight(fonts.normal.style),
-      ].reduce((a, b) => a + b, 0) / 2
+      SIMPLE_CATEGORIES.map((c) => getFontWeight(fonts[c].style)).reduce(
+        (a, b) => a + b,
+        0,
+      ) / SIMPLE_CATEGORIES.length
     );
   }
   if (fontMode === 'advanced') {
     const fonts = _fonts as Record<AdvancedCategory, FontName>;
     return (
-      [
-        getFontWeight(fonts.kanji.style),
-        getFontWeight(fonts.kana.style),
-        getFontWeight(fonts.yakumono.style),
-        getFontWeight(fonts.number.style),
-        getFontWeight(fonts.normal.style),
-      ].reduce((a, b) => a + b, 0) / 5
+      ADVANCED_CATEGORIES.map((c) => getFontWeight(fonts[c].style)).reduce(
+        (a, b) => a + b,
+        0,
+      ) / ADVANCED_CATEGORIES.length
     );
   }
   return 400;
 };
 
-export const StylesTab = ({ styles }: {
+export const StylesTab = ({
+  styles,
+}: {
   styles: Style[];
 }) => {
   return (

--- a/src/tabs/text.tsx
+++ b/src/tabs/text.tsx
@@ -24,6 +24,7 @@ import type {
   SelectionChangeHandler,
   SaveStyleHandler,
 } from '../types';
+import { ADVANCED_CATEGORIES, SIMPLE_CATEGORIES } from '../types';
 import { Textbox } from '../components/textbox';
 
 export type UIProps = {
@@ -74,7 +75,10 @@ const FontSelector = (props: {
   };
 
   return (
-    <Container space="extraSmall" style={{ display: 'flex', gap: 8, position: 'relative' }}>
+    <Container
+      space="extraSmall"
+      style={{ display: 'flex', gap: 8, position: 'relative' }}
+    >
       <div style={{ minWidth: '60%' }}>
         <FilterInput
           options={familyOptions}
@@ -125,9 +129,7 @@ export const TextTab = ({
   }, []);
 
   const categories =
-    mode === 'advanced'
-      ? (['kanji', 'kana', 'yakumono', 'number', 'normal'] as const)
-      : (['japanese', 'normal'] as const);
+    mode === 'advanced' ? ADVANCED_CATEGORIES : SIMPLE_CATEGORIES;
 
   const [isOpen, setOpen] = useState(false);
   const [name, setName] = useState('');

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,15 @@ export type AdvancedCategory =
   | 'yakumono'
   | 'number'
   | 'normal';
+
+export const SIMPLE_CATEGORIES = ['japanese', 'normal'] as const;
+export const ADVANCED_CATEGORIES = [
+  'kanji',
+  'kana',
+  'yakumono',
+  'number',
+  'normal',
+] as const;
 export type Category = SimpleCategory | AdvancedCategory;
 export type Fonts = Record<Category, FontName>;
 export type SavedFonts =


### PR DESCRIPTION
## Summary
- define `SIMPLE_CATEGORIES` and `ADVANCED_CATEGORIES` in `types.ts`
- reuse these constants across `main.ts`, `text.tsx` and `styles.tsx`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6848f354185c832c80b2224626f2f958